### PR TITLE
Update to Code.fromAsset

### DIFF
--- a/lib/cloudtrail_partitioner-stack.js
+++ b/lib/cloudtrail_partitioner-stack.js
@@ -34,7 +34,7 @@ class CloudtrailPartitionerStack extends cdk.Stack {
     // Create Lambda
     const partitioner = new lambda.Function(this, "partitioner", {
       runtime: lambda.Runtime.PYTHON_3_7,
-      code: lambda.Code.asset("resources/partitioner"),
+      code: lambda.Code.fromAsset("resources/partitioner"),
       handler: "main.handler",
       description: "Partitions the Athena table for CloudTrail",
       logRetention: logs.RetentionDays.TWO_WEEKS,
@@ -136,7 +136,7 @@ class CloudtrailPartitionerStack extends cdk.Stack {
     // Create Lambda to forward alarms
     const alarm_forwarder = new lambda.Function(this, "alarm_forwarder", {
       runtime: lambda.Runtime.PYTHON_3_7,
-      code: lambda.Code.asset("resources/alarm_forwarder"),
+      code: lambda.Code.fromAsset("resources/alarm_forwarder"),
       handler: "main.handler",
       description: "Forwards alarms from the local SNS to another",
       logRetention: logs.RetentionDays.TWO_WEEKS,


### PR DESCRIPTION
Update `lib/cloudtrail_partitioner-stack.js` to use `lambda.Code.fromAsset` instead of `lambda.Code.asset` to resolve warnings:
```
[WARNING] @aws-cdk/aws-lambda.Code#asset is deprecated.
  use `fromAsset`
  This API will be removed in the next major release.
[WARNING] @aws-cdk/aws-lambda.Code#asset is deprecated.
  use `fromAsset`
  This API will be removed in the next major release.
```